### PR TITLE
chore(travis-ci): removed iojs and added node 8, 9, 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
+  - "10"      
+  - "9"
+  - "8"
   - "7"
   - "6"
   - "5"
   - "4"
-  - "iojs"
   - "node"
 notifications:
   email: true


### PR DESCRIPTION
`iojs` looks doesn't have much popularity, so, remove the continuous checking for it. Also, added new versions of nodejs 8, 9, 10.